### PR TITLE
Evig loooooooop fix

### DIFF
--- a/force-app/main/default/classes/HOT_ClaimController.cls
+++ b/force-app/main/default/classes/HOT_ClaimController.cls
@@ -630,6 +630,7 @@ public without sharing class HOT_ClaimController {
     }
     public static void setEntitlementOnClaim(Set<Id> claimIds) {
         List<HOT_Claim__c> claims = [SELECT Id, Account__c, Type__c FROM HOT_Claim__c WHERE Id IN :claimIds];
+        List<HOT_Claim__c> claimsToBeUpdated = new List<HOT_Claim__c>();
 
         Set<Id> accountIds = new Set<Id>();
         for (HOT_Claim__c claim : claims) {
@@ -674,13 +675,14 @@ public without sharing class HOT_ClaimController {
                                 entitlement.ToDate__c >= latestEndTime
                             ) {
                                 claim.Entitlement__c = entitlement.Id;
+                                claimsToBeUpdated.add(claim);
                                 break;
                             }
                         }
                     }
                 }
                 try {
-                    update claims;
+                    update claimsToBeUpdated;
                 } catch (Exception e) {
                     LoggerUtility logger = new LoggerUtility();
                     logger.exception(e, CRM_ApplicationDomain.Domain.HOT);


### PR DESCRIPTION
Problemet var at når jeg oppdaterte hele listen, så "oppdaterte" den de kravene som ikke hadde vedtak også. Derfor ville de som ikke ha vedtak gå i evig loop i afterupdate. 

_OG SÅ ble det problemer med validation rules (bare i uat da), siden jeg testet det på vedtak som var Godkjent av NAV, og har laget en valideringsregel at de kan ikke bli godkjent av nav når de ikke har påkoblet et vedtak. Så måtte sette det til false._  Det kommer jo ikke til å skje i prod.