### PR TITLE
Fjerne Claim Line Items tab

### DIFF
--- a/force-app/main/default/applications/HOT_Lesehjelp.app-meta.xml
+++ b/force-app/main/default/applications/HOT_Lesehjelp.app-meta.xml
@@ -33,7 +33,6 @@
     <navType>Standard</navType>
     <tabs>standard-Account</tabs>
     <tabs>HOT_Claim__c</tabs>
-    <tabs>HOT_ClaimLineItem__c</tabs>
     <tabs>HOT_Entitlement__c</tabs>
     <tabs>standard-report</tabs>
     <tabs>standard-Dashboard</tabs>

--- a/force-app/main/default/audience/Default_lesehjelp.audience-meta.xml
+++ b/force-app/main/default/audience/Default_lesehjelp.audience-meta.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Audience xmlns="http://soap.sforce.com/2006/04/metadata">
-    <audienceName>Default</audienceName>
-    <container>lesehjelp</container>
-    <criteria/>
-    <formulaFilterType>AllCriteriaMatch</formulaFilterType>
-    <isDefaultAudience>true</isDefaultAudience>
-</Audience>

--- a/force-app/main/default/audience/Default_lesehjelp.audience-meta.xml
+++ b/force-app/main/default/audience/Default_lesehjelp.audience-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Audience xmlns="http://soap.sforce.com/2006/04/metadata">
+    <audienceName>Default</audienceName>
+    <container>lesehjelp</container>
+    <criteria/>
+    <formulaFilterType>AllCriteriaMatch</formulaFilterType>
+    <isDefaultAudience>true</isDefaultAudience>
+</Audience>


### PR DESCRIPTION
Remove the tab 'Claim Line items' from the navigation items of Lesehjelp app