### PR TITLE
Claim record page- rename Section to Informasjon

### DIFF
--- a/force-app/main/default/flexipages/HOT_Claim_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/HOT_Claim_Record_Page.flexipage-meta.xml
@@ -329,7 +329,7 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
-                    <value>Section</value>
+                    <value>Informasjon</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection</identifier>


### PR DESCRIPTION
On the claim record page, section is renamed to Informasjon