### PR TITLE
Tolk 2492 lesehjelp økt testdekning ClaimController og CreateClaimLineItem

### DIFF
--- a/force-app/main/default/classes/HOT_ClaimController.cls
+++ b/force-app/main/default/classes/HOT_ClaimController.cls
@@ -1,4 +1,10 @@
 public without sharing class HOT_ClaimController {
+    private static String handleExceptionAndGetMessage(Exception e) {
+        LoggerUtility logger = new LoggerUtility();
+        logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
+        logger.publishSynch();
+        return e.getMessage();
+    }
     @AuraEnabled
     public static Boolean checkAccess(String claimId) {
         User currentUser = [SELECT Id, AccountId, Account.CRM_Person__c FROM User WHERE Id = :UserInfo.getUserId()];
@@ -216,10 +222,7 @@ public without sharing class HOT_ClaimController {
             insert claimLineItemList;
             return '';
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility();
-            logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-            logger.publishSynch();
-            return e.getMessage();
+            return handleExceptionAndGetMessage(e);
         }
     }
 
@@ -250,10 +253,7 @@ public without sharing class HOT_ClaimController {
             String result = createClaimLineItems(newClaim, claimLineItems);
             return 'ok' + result;
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility();
-            logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-            logger.publishSynch();
-            return e.getMessage();
+            return handleExceptionAndGetMessage(e);
         }
     }
     private static String createClaimOrganization(
@@ -293,10 +293,7 @@ public without sharing class HOT_ClaimController {
             String result = createClaimLineItems(newClaim, claimLineItems);
             return 'ok' + result;
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility();
-            logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-            logger.publishSynch();
-            return e.getMessage();
+            return handleExceptionAndGetMessage(e);
         }
     }
     private static List<String> addUserPhoneVariations(List<String> idents, String phoneNumber) {
@@ -400,10 +397,7 @@ public without sharing class HOT_ClaimController {
                 update claims;
                 return 'ok';
             } catch (Exception e) {
-                LoggerUtility logger = new LoggerUtility();
-                logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
-                return e.getMessage();
+                return handleExceptionAndGetMessage(e);
             }
         } else {
             return '';
@@ -424,10 +418,7 @@ public without sharing class HOT_ClaimController {
                 update claims;
                 return 'ok';
             } catch (Exception e) {
-                LoggerUtility logger = new LoggerUtility();
-                logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
-                return e.getMessage();
+                return handleExceptionAndGetMessage(e);
             }
         } else {
             return '';
@@ -442,10 +433,7 @@ public without sharing class HOT_ClaimController {
                 update claims;
                 return 'ok';
             } catch (Exception e) {
-                LoggerUtility logger = new LoggerUtility();
-                logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
-                return e.getMessage();
+                return handleExceptionAndGetMessage(e);
             }
         } else {
             return '';
@@ -597,10 +585,7 @@ public without sharing class HOT_ClaimController {
                 return 'Dette kravet kan ikke endres. Det er allerede godkjent av NAV.';
             }
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility();
-            logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-            logger.publishSynch();
-            return e.getMessage();
+            return handleExceptionAndGetMessage(e);
         }
     }
 
@@ -772,10 +757,7 @@ public without sharing class HOT_ClaimController {
             delete recordToDelete;
             return '';
         } catch (Exception e) {
-            LoggerUtility logger = new LoggerUtility();
-            logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-            logger.publishSynch();
-            return e.getMessage();
+            return handleExceptionAndGetMessage(e);
         }
     }
 
@@ -835,9 +817,7 @@ public without sharing class HOT_ClaimController {
                 try {
                     update claimsToBeUpdated;
                 } catch (Exception e) {
-                    LoggerUtility logger = new LoggerUtility();
-                    logger.exception(e, CRM_ApplicationDomain.Domain.HOT);
-                    logger.publishSynch();
+                    handleExceptionAndGetMessage(e);
                 }
             }
         }

--- a/force-app/main/default/classes/HOT_ClaimControllerTest.cls
+++ b/force-app/main/default/classes/HOT_ClaimControllerTest.cls
@@ -2,28 +2,47 @@
 public class HOT_ClaimControllerTest {
     @TestSetup
     static void setup() {
-        Account acc = new Account();
-        acc.Name = 'Ola Lesehjelp';
-        insert acc;
-        Account acc2 = new Account();
-        acc2.INT_PersonIdent__c = '01010101010';
-        acc2.Name = 'Kari Bruker';
-        acc2.INT_KrrMobilePhone__c = '12345678';
-        insert acc2;
-        Account acc3 = new Account();
-        acc3.Name = 'NAV';
-        acc3.INT_OrganizationNumber__c = '123456789';
-        insert acc3;
-        HOT_Claim__c claim = HOT_LesehjelpTestDataFactory.createClaim(acc2, acc);
-        claim.UserPersonNumber__c = '01010101010';
-        insert claim;
+        User navEmployee = TestDataFactory_Community.getUsers(1, 'System Administrator', true, true)[0];
+        System.runAs(navEmployee) {
+            Account acc = new Account();
+            acc.Name = 'Ola Lesehjelp';
+            insert acc;
+            Account acc2 = new Account();
+            acc2.INT_PersonIdent__c = '01010101010';
+            acc2.Name = 'Kari Bruker';
+            acc2.INT_KrrMobilePhone__c = '12345678';
+            insert acc2;
+            Account acc3 = new Account();
+            acc3.Name = 'NAV';
+            acc3.INT_OrganizationNumber__c = '123456789';
+            insert acc3;
+            HOT_Claim__c claim = HOT_LesehjelpTestDataFactory.createClaim(acc2, acc);
+            claim.UserPersonNumber__c = '01010101010';
+            insert claim;
 
-        HOT_Entitlement__c entitlement = HOT_LesehjelpTestDataFactory.createEntitlement(acc2);
-        insert entitlement;
+            HOT_Entitlement__c entitlement = HOT_LesehjelpTestDataFactory.createEntitlement(acc2);
+            insert entitlement;
+
+
+            // Oppsett portalbruker
+            Account personAccount = TestDataFactory_Community.getPersonAccounts(1)[0];
+            personAccount.LastName = 'PortalBruker';
+            update personAccount;
+            Person__c person = [SELECT INT_LastName__c, CRM_Account__c FROM Person__c];
+            person.CRM_Account__c = personAccount.Id;
+            Set<Id> personAccountIds=new Set<Id>();
+            personAccountIds.add(personAccount.Id);
+            update person;
+            List<User> users = TestDataFactory_Community.getEmployerCommunityUser(
+                personAccountIds, 
+                'Trial Customer Portal User', 
+                true
+                );
+        }
     }
     @IsTest
     static void setEntitlementOnClaimTest() {
-        HOT_Claim__c claim = [SELECT Id FROM HOT_Claim__c];
+    HOT_Claim__c claim = [SELECT Id FROM HOT_Claim__c];
         HOT_ClaimLineItem__c cli = HOT_LesehjelpTestDataFactory.createClaimLineItems(claim);
         insert cli;
         Test.startTest();
@@ -418,6 +437,55 @@ public class HOT_ClaimControllerTest {
         Test.stopTest();
         System.assertEquals(null, null, 'List of times should come back null because no access');
     }
+    @IsTest
+    static void getTimesAsValidUserTest() {
+        Account portalBrukerAccount = [
+            SELECT Id FROM Account
+            WHERE LastName = 'PortalBruker'
+        ];
+        
+        HOT_Claim__c newClaim = HOT_LesehjelpTestDataFactory.createClaim(
+            HOT_LesehjelpTestDataFactory.createAccount(true),
+            portalBrukerAccount
+            );
+
+        insert newClaim;
+
+        HOT_ClaimLineItem__c cli = HOT_LesehjelpTestDataFactory.createClaimLineItems(newClaim);
+
+        Date yesterday = Date.today().addDays(-1);
+        cli.Date__c = yesterday;
+        cli.StartTime__c = DateTime.newInstance(yesterday, Time.newInstance(13, 0, 0, 0));
+        cli.EndTime__c = DateTime.newInstance(yesterday, Time.newInstance(17, 0, 0, 0));
+        cli.TypeOfTask__c = '';
+        cli.HasTravelTo__c = true;
+        cli.HasTravelFrom__c = true;
+        cli.TravelTo__c = yesterday;
+        cli.TravelFrom__c = yesterday;
+        cli.TravelToStartTime__c = DateTime.newInstance(yesterday, Time.newInstance(10, 0, 0, 0));
+        cli.TravelToEndTime__c = DateTime.newInstance(yesterday, Time.newInstance(11, 0, 0, 0));
+        cli.TravelFromStartTime__c = DateTime.newInstance(yesterday, Time.newInstance(13, 0, 0, 0));
+        cli.TravelFromEndTime__c = DateTime.newInstance(yesterday, Time.newInstance(14, 0, 0, 0));
+        cli.TravelDistance__c = 10;
+        cli.ExpensesPublicTransport__c = 10;
+        cli.ExpensesParking__c = 10;
+        cli.ExpensesToll__c = 0;
+        insert cli;
+
+        User portalBruker = [
+            SELECT Id, AccountId FROM User 
+            WHERE AccountId = :portalBrukerAccount.Id
+        ]; 
+
+        List<Map<String, String>> times = new List<Map<String, String>>();
+        Test.startTest();
+        System.runAs(portalBruker) {
+            times = HOT_ClaimController.getTimes(newClaim.Id);
+        }
+        Test.stopTest();
+        System.assertEquals(1, times.size(), 'Should have 1 time');
+    }
+
     @IsTest
     static void CreateNewClaimFromCommunityAndThenUpdateItTest() {
         String userName = 'Test User';

--- a/force-app/main/default/classes/HOT_ClaimControllerTest.cls
+++ b/force-app/main/default/classes/HOT_ClaimControllerTest.cls
@@ -435,7 +435,7 @@ public class HOT_ClaimControllerTest {
         Test.startTest();
         List<Map<String, String>> times = HOT_ClaimController.getTimes(claim.Id);
         Test.stopTest();
-        System.assertEquals(null, null, 'List of times should come back null because no access');
+        System.assertEquals(null, times, 'List of times should come back null because no access');
     }
     @IsTest
     static void getTimesAsValidUserTest() {

--- a/force-app/main/default/classes/HOT_ClaimControllerTest.cls
+++ b/force-app/main/default/classes/HOT_ClaimControllerTest.cls
@@ -41,6 +41,29 @@ public class HOT_ClaimControllerTest {
         }
     }
     @IsTest
+    static void checkAccessTest() {
+        Account portalBrukerAccount = [
+            SELECT Id FROM Account
+            WHERE LastName = 'PortalBruker'
+        ];
+        
+        HOT_Claim__c newClaim = HOT_LesehjelpTestDataFactory.createClaim(
+            HOT_LesehjelpTestDataFactory.createAccount(true),
+            portalBrukerAccount
+            );
+        insert newClaim;
+
+        User portalBruker = [
+            SELECT Id, AccountId FROM User 
+            WHERE AccountId = :portalBrukerAccount.Id
+        ]; 
+        
+        System.assertEquals(false, HOT_ClaimController.checkAccess(newClaim.Id), 'Default user should not have access');
+        System.runAs(portalBruker) {
+            System.assertEquals(true, HOT_ClaimController.checkAccess(newClaim.Id), 'Claimant should have access');
+        }
+    }
+    @IsTest
     static void setEntitlementOnClaimTest() {
     HOT_Claim__c claim = [SELECT Id FROM HOT_Claim__c];
         HOT_ClaimLineItem__c cli = HOT_LesehjelpTestDataFactory.createClaimLineItems(claim);

--- a/force-app/main/default/classes/HOT_CreateClaimLineItem.cls
+++ b/force-app/main/default/classes/HOT_CreateClaimLineItem.cls
@@ -38,6 +38,13 @@ public without sharing class HOT_CreateClaimLineItem {
     @InvocableVariable
     public Integer distanceTraveled;
 
+    public static final String ERROR_ENDDATE_BEFORE_STARTDATE = 'Slutt tid må være etter start tid.';
+    public static final String ERROR_RECURRING_ENDDATE_BEFORE_STARTDATE = 'Sluttdato må være etter startdato.';
+    public static final String ERROR_NO_DAY_SELECTED = 'Må velge minst en dag.';
+    public static final String ERROR_FAILED_WORKORDER_CREATION = 'Opprettelsen av arbeidsordrene feilet.';
+    public static final String ERROR_FAILED_CLAIM_LINE_CREATION = 'Opprettelsen av lesekravslinje feilet.';
+    public static final String ERROR_EXCEEDED_MAX_ITEMS = 'Kan ikke opprette mer enn 200 lesekravslinjer av gangen';
+
     @InvocableMethod
     public static List<String> createClaimLineItems(List<HOT_CreateClaimLineItem> inputVariables) {
         HOT_CreateClaimLineItem input = inputVariables[0];
@@ -50,12 +57,12 @@ public without sharing class HOT_CreateClaimLineItem {
         TimeZone tz = UserInfo.getTimeZone();
         Datetime oldStartDate = input.startDate;
         if (input.endDate <= input.startDate) {
-            errors.add('Slutt tid må være etter start tid.');
+            errors.add(ERROR_ENDDATE_BEFORE_STARTDATE);
             return errors;
         }
 
         if (input.recurringType != 'Never' && input.recurringEndDate <= input.startDate.date()) {
-            errors.add('Sluttdato må være etter startdato.');
+            errors.add(ERROR_RECURRING_ENDDATE_BEFORE_STARTDATE);
             return errors;
         }
 
@@ -70,7 +77,7 @@ public without sharing class HOT_CreateClaimLineItem {
             !input.saturday &&
             !input.sunday
         ) {
-            errors.add('Må velge minst en dag.');
+            errors.add(ERROR_NO_DAY_SELECTED);
             return errors;
         }
 
@@ -91,7 +98,7 @@ public without sharing class HOT_CreateClaimLineItem {
             try {
                 insert claimLineItem;
             } catch (Exception e) {
-                errors.add('Opprettelsen av lesekravslinje feilet.');
+                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
                 logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
                 logger.publishSynch();
             }
@@ -102,7 +109,7 @@ public without sharing class HOT_CreateClaimLineItem {
             Integer numberOfRecurrences = input.startDate.date().daysBetween(input.recurringEndDate);
 
             if (numberOfRecurrences > maxNumberOfRecurrences) {
-                errors.add('Kan ikke opprette flere enn 200 lesekravslinjer av gangen');
+                errors.add(ERROR_EXCEEDED_MAX_ITEMS);
                 return errors;
             }
 
@@ -139,7 +146,7 @@ public without sharing class HOT_CreateClaimLineItem {
             try {
                 insert claimLineItems;
             } catch (Exception e) {
-                errors.add('Opprettelsen av arbeidsordrene feilet.');
+                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
                 logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
                 logger.publishSynch();
             }
@@ -192,14 +199,14 @@ public without sharing class HOT_CreateClaimLineItem {
             }
 
             if (claimLineItems.size() > maxNumberOfRecurrences) {
-                errors.add('Kan ikke opprette mer enn 200 lesekravslinjer av gangen');
+                errors.add(ERROR_EXCEEDED_MAX_ITEMS);
                 return errors;
             }
 
             try {
                 insert claimLineItems;
             } catch (Exception e) {
-                errors.add('Opprettelsen av lesekravslinje feilet.');
+                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
                 logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
                 logger.publishSynch();
             }
@@ -255,14 +262,14 @@ public without sharing class HOT_CreateClaimLineItem {
             }
 
             if (claimLineItems.size() > maxNumberOfRecurrences) {
-                errors.add('Kan ikke opprette mer enn 200 lesekravslinjer av gangen');
+                errors.add(ERROR_EXCEEDED_MAX_ITEMS);
                 return errors;
             }
 
             try {
                 insert claimLineItems;
             } catch (Exception e) {
-                errors.add('Opprettelsen av lesekravslinjer feilet.');
+                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
                 logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
                 logger.publishSynch();
             }

--- a/force-app/main/default/classes/HOT_CreateClaimLineItem.cls
+++ b/force-app/main/default/classes/HOT_CreateClaimLineItem.cls
@@ -45,6 +45,12 @@ public without sharing class HOT_CreateClaimLineItem {
     public static final String ERROR_FAILED_CLAIM_LINE_CREATION = 'Opprettelsen av lesekravslinje feilet.';
     public static final String ERROR_EXCEEDED_MAX_ITEMS = 'Kan ikke opprette mer enn 200 lesekravslinjer av gangen';
 
+    private static void handleException(LoggerUtility logger, List<String> errors, String error, SObject relatedRecord, Exception e) {
+        errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
+        logger.exception(e, relatedRecord, CRM_ApplicationDomain.Domain.HOT);
+        logger.publishSynch();
+    }
+
     @InvocableMethod
     public static List<String> createClaimLineItems(List<HOT_CreateClaimLineItem> inputVariables) {
         HOT_CreateClaimLineItem input = inputVariables[0];
@@ -98,9 +104,7 @@ public without sharing class HOT_CreateClaimLineItem {
             try {
                 insert claimLineItem;
             } catch (Exception e) {
-                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
-                logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
+                handleException(logger, errors, ERROR_FAILED_CLAIM_LINE_CREATION, claim, e);
             }
 
             return errors;
@@ -146,9 +150,7 @@ public without sharing class HOT_CreateClaimLineItem {
             try {
                 insert claimLineItems;
             } catch (Exception e) {
-                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
-                logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
+                handleException(logger, errors, ERROR_FAILED_CLAIM_LINE_CREATION, claim, e);
             }
 
             return errors;
@@ -206,9 +208,7 @@ public without sharing class HOT_CreateClaimLineItem {
             try {
                 insert claimLineItems;
             } catch (Exception e) {
-                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
-                logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
+                handleException(logger, errors, ERROR_FAILED_CLAIM_LINE_CREATION, claim, e);
             }
 
             return errors;
@@ -269,9 +269,7 @@ public without sharing class HOT_CreateClaimLineItem {
             try {
                 insert claimLineItems;
             } catch (Exception e) {
-                errors.add(ERROR_FAILED_CLAIM_LINE_CREATION);
-                logger.exception(e, claim, CRM_ApplicationDomain.Domain.HOT);
-                logger.publishSynch();
+                handleException(logger, errors, ERROR_FAILED_CLAIM_LINE_CREATION , claim, e);
             }
 
             return errors;

--- a/force-app/main/default/classes/HOT_CreateClaimLineItemTest.cls
+++ b/force-app/main/default/classes/HOT_CreateClaimLineItemTest.cls
@@ -21,7 +21,6 @@ private class HOT_CreateClaimLineItemTest {
         HOT_Entitlement__c entitlement = HOT_LesehjelpTestDataFactory.createEntitlement(acc2);
         insert entitlement;
     }
-
     @IsTest
     private static void createClaimNever() {
         HOT_Claim__c claim = [SELECT Id FROM HOT_Claim__c];
@@ -172,5 +171,122 @@ private class HOT_CreateClaimLineItemTest {
             FROM HOT_ClaimLineItem__c
         ];
         System.assertEquals(14, claimLines.size(), 'Det ble ikke opprettet korrekt antall linjer');
+    }
+    @IsTest
+    private static void createClaimInvalidStartEndTime() {
+        HOT_Claim__c claim =  [SELECT Id FROM HOT_Claim__c];
+        HOT_CreateClaimLineItem inputVariable = new HOT_CreateClaimLineItem();
+        inputVariable.claimId = claim.Id;
+        inputVariable.endDate = Datetime.now();
+        inputVariable.startDate = Datetime.now().addHours(1);
+
+        Test.startTest();
+        List<String> errors = 
+            HOT_CreateClaimLineItem.createClaimLineItems(new List<HOT_CreateClaimLineItem>{inputVariable});
+        Test.stopTest();
+
+        System.assert(
+            errors.contains( HOT_CreateClaimLineItem.ERROR_ENDDATE_BEFORE_STARTDATE), 
+            'Errors should include enddate before startdate error'
+            );
+    }
+    @IsTest
+    private static void createClaimInvalidRecurringStartEndTime() {
+        HOT_Claim__c claim =  [SELECT Id FROM HOT_Claim__c];
+        HOT_CreateClaimLineItem inputVariable = new HOT_CreateClaimLineItem();
+        inputVariable.claimId = claim.Id;
+        inputVariable.recurringType = 'Weekly';
+        inputVariable.recurringEndDate = Date.today();
+        inputVariable.startDate = DateTime.now().addDays(1);
+
+        Test.startTest();
+        List<String> errors = 
+            HOT_CreateClaimLineItem.createClaimLineItems(new List<HOT_CreateClaimLineItem>{inputVariable});
+        Test.stopTest();
+
+        System.assert(
+            errors.contains(HOT_CreateClaimLineItem.ERROR_RECURRING_ENDDATE_BEFORE_STARTDATE),
+            'Errors should include recurring enddate before startdate error'
+        );
+    }
+    @IsTest 
+    private static void createClaimNoDaySelected() {
+        HOT_Claim__c claim =  [SELECT Id FROM HOT_Claim__c];
+        HOT_CreateClaimLineItem inputVariable = new HOT_CreateClaimLineItem();
+        inputVariable.claimId = claim.Id;
+        inputVariable.startDate = Datetime.now();
+        inputVariable.endDate = Datetime.now().addHours(1);
+        inputVariable.recurringType = 'Weekly';
+        inputVariable.travelToStartDate = Datetime.now().addHours(-1);
+        inputVariable.travelToEndDate = Datetime.now();
+        inputVariable.travelFromStartDate = Datetime.now().addHours(1);
+        inputVariable.travelFromEndDate = Datetime.now().addHours(2);
+        inputVariable.monday = false;
+        inputVariable.tuesday = false;
+        inputVariable.wednesday = false;
+        inputVariable.thursday = false;
+        inputVariable.friday = false;
+        inputVariable.saturday = false;
+        inputVariable.sunday = false;
+
+        Test.startTest();
+        List<String> errors = 
+            HOT_CreateClaimLineItem.createClaimLineItems(new List<HOT_CreateClaimLineItem>{inputVariable});
+        Test.stopTest();
+
+        System.assert(
+            errors.contains(HOT_CreateClaimLineItem.ERROR_NO_DAY_SELECTED),
+            'Errors should include no selected day error'
+        );
+    }
+    @IsTest
+    private static void createClaimTooManyDays() {
+        HOT_Claim__c claim =  [SELECT Id FROM HOT_Claim__c];
+        HOT_CreateClaimLineItem inputVariable = new HOT_CreateClaimLineItem();
+        inputVariable.claimId = claim.Id;
+        inputVariable.startDate = Datetime.now();
+        inputVariable.endDate = Datetime.now().addHours(1);
+        inputVariable.recurringType = 'Weekly';
+        inputVariable.travelToStartDate = Datetime.now().addHours(-1);
+        inputVariable.travelToEndDate = Datetime.now();
+        inputVariable.travelFromStartDate = Datetime.now().addHours(1);
+        inputVariable.travelFromEndDate = Datetime.now().addHours(2);
+        inputVariable.recurringEndDate = Date.today().addYears(10);
+        inputVariable.monday = true;
+        inputVariable.tuesday = true;
+        inputVariable.wednesday = true;
+        inputVariable.thursday = true;
+        inputVariable.friday = true;
+        inputVariable.saturday = true;
+        inputVariable.sunday = true;
+
+        Test.startTest();
+        List<String> errorsWhenWeekly = 
+            HOT_CreateClaimLineItem.createClaimLineItems(new List<HOT_CreateClaimLineItem>{inputVariable});
+
+
+        inputVariable.recurringType = 'Biweekly';
+        List<String> errorsWhenBiweekly = 
+            HOT_CreateClaimLineItem.createClaimLineItems(new List<HOT_CreateClaimLineItem>{inputVariable});
+
+        inputVariable.recurringType = 'Daily';
+        List<String> errorsWhenDaily = 
+            HOT_CreateClaimLineItem.createClaimLineItems(new List<HOT_CreateClaimLineItem>{inputVariable});
+
+
+        Test.stopTest();
+
+        System.assert(
+            errorsWhenWeekly.contains(HOT_CreateClaimLineItem.ERROR_EXCEEDED_MAX_ITEMS),
+            'Errors should include too many items error when weekly'
+        );
+        System.assert(
+            errorsWhenBiweekly.contains(HOT_CreateCLaimLineItem.ERROR_EXCEEDED_MAX_ITEMS),
+            'Erros should include too many items error when biweekly'
+        );
+        System.assert(
+            errorsWhenDaily.contains(HOT_CreateCLaimLineItem.ERROR_EXCEEDED_MAX_ITEMS),
+            'Erros should include too many items error when daily'
+        );
     }
 }


### PR DESCRIPTION
Øker testdekning av klassene:
- HOT_ClaimController : 87%
- HOT_CreateClaimLineItem: 93%

Obs: Involverer noe endring på klassene som er testet for å gjøre testing enklere for CreateClaimLineItem, samt reduksjon i omfang av kodelinjer i catch-blokker ved bruk av private hjelpemetoder.


