### PR TITLE
Setter alle felter på arbeidgiver info til null igjen når de går fra Nei til Ja igjen

### DIFF
--- a/force-app/main/default/lwc/hot_claimForm/hot_claimForm.js
+++ b/force-app/main/default/lwc/hot_claimForm/hot_claimForm.js
@@ -116,6 +116,11 @@ export default class Hot_claimForm extends LightningElement {
         this.componentValues.onEmployerRadioButtons = event.detail;
         if (event.detail[0].checked) {
             this.employerClaim = true;
+            if (this.isEdit == false) {
+                this.fieldValues.EmployerName__c = '';
+                this.fieldValues.EmployerNumber__c = '';
+                this.fieldValues.EmployerExpensesPerHour__c = '';
+            }
             if (this.isLos == false) {
                 this.showNewLos = false;
             }


### PR DESCRIPTION
For å unngå at feilmelding ved innsending etter man har fylt ut, trykket nei, og deretter ja igjen