### PR TITLE
TOLK-3075 : Fjerner beregningen av ventetid mellom reisetiden og faktisk oppdrag start

### DIFF
--- a/force-app/main/default/classes/HOT_ClaimLineItemController.cls
+++ b/force-app/main/default/classes/HOT_ClaimLineItemController.cls
@@ -100,7 +100,7 @@ public without sharing class HOT_ClaimLineItemController {
             WHERE
                 Claim__r.Claimant__c = :currentUser.AccountId
                 AND Claim__r.Status__c != 'Withdrawn'
-                AND  Claim__r.Id != :recordId
+                AND Claim__r.Id != :recordId
         ];
         return claimLineItems;
     }
@@ -239,7 +239,10 @@ public without sharing class HOT_ClaimLineItemController {
 
             Integer travelMinutes = 0;
             if (claimLineItem.HasTravelTo__c) {
-                travelMinutes += calculateTravelMinutes(claimLineItem.TravelToStartTime__c, claimLineItem.StartTime__c);
+                travelMinutes += calculateTravelMinutes(
+                    claimLineItem.TravelToStartTime__c,
+                    claimLineItem.TravelToEndTime__c
+                );
             }
             if (claimLineItem.HasTravelFrom__c) {
                 travelMinutes += calculateTravelMinutes(

--- a/force-app/main/default/classes/HOT_ClaimLineItemController.cls
+++ b/force-app/main/default/classes/HOT_ClaimLineItemController.cls
@@ -237,21 +237,24 @@ public without sharing class HOT_ClaimLineItemController {
             DateTime claimDateTime = claimLineItem.StartTime__c;
             Boolean isSunday = (claimDateTime.format('EEEE') == 'Sunday');
 
-            Integer travelMinutes = 0;
+            Integer travelToMinutes = 0;
+            Integer travelFromMinutes = 0;
             if (claimLineItem.HasTravelTo__c) {
-                travelMinutes += calculateTravelMinutes(
+                travelToMinutes += calculateTravelMinutes(
                     claimLineItem.TravelToStartTime__c,
                     claimLineItem.TravelToEndTime__c
                 );
             }
             if (claimLineItem.HasTravelFrom__c) {
-                travelMinutes += calculateTravelMinutes(
+                travelFromMinutes += calculateTravelMinutes(
                     claimLineItem.TravelFromStartTime__c,
                     claimLineItem.TravelFromEndTime__c
                 );
             }
-            Integer roundedTravelMinutes = roundMinutes(travelMinutes);
-            Double travelHours = roundedTravelMinutes / 60.0;
+            Integer roundedTravelToMinutes = roundMinutes(travelToMinutes);
+            Integer roundedTravelFromMinutes = roundMinutes(travelFromMinutes);
+            Integer roundenTotalTravelMinutes = roundedTravelToMinutes + roundedTravelFromMinutes;
+            Double travelHours = roundenTotalTravelMinutes / 60.0;
             claimLineItem.TravelHours__c = travelHours;
 
             if (holidayDates.contains(claimDate) || isSunday) {

--- a/force-app/main/default/lwc/hot_claimLineItemTable/hot_claimLineItemTable.html
+++ b/force-app/main/default/lwc/hot_claimLineItemTable/hot_claimLineItemTable.html
@@ -46,7 +46,7 @@
                 <div class="right-content satser">
                     <p><strong>Timer med dagsats: </strong>{cli.DayHours__c}</p>
                     <p><strong>Timer med kveld/natt/helgesats: </strong>{cli.EveningNightAndWeekendHours__c}</p>
-                    <p><strong>Timer med reise (inkl ventetid): </strong>{cli.TravelHours__c}</p>
+                    <p><strong>Timer med reise: </strong>{cli.TravelHours__c}</p>
                 </div>
             </div>
         </div>

--- a/force-app/main/default/objects/HOT_Claim__c/fields/TotalTravelHours__c.field-meta.xml
+++ b/force-app/main/default/objects/HOT_Claim__c/fields/TotalTravelHours__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TotalTravelHours__c</fullName>
     <externalId>false</externalId>
-    <inlineHelpText>Inkluderer ventetid</inlineHelpText>
+    <inlineHelpText></inlineHelpText>
     <label>Total travel hours</label>
     <summarizedField>HOT_ClaimLineItem__c.TravelHours__c</summarizedField>
     <summaryForeignKey>HOT_ClaimLineItem__c.Claim__c</summaryForeignKey>


### PR DESCRIPTION
For å unngå misbruk av reisetiden blir beregningen av tiden mellom reisens slutt og stattid på oppdraget fjernet. De som har nødvendig reisetid skal velge reise helt til oppdragets start