### PR TITLE
TOLK-3215 : Skal summeres FØR opprunding til neste 30 min

### DIFF
--- a/force-app/main/default/classes/HOT_ClaimLineItemController.cls
+++ b/force-app/main/default/classes/HOT_ClaimLineItemController.cls
@@ -251,10 +251,9 @@ public without sharing class HOT_ClaimLineItemController {
                     claimLineItem.TravelFromEndTime__c
                 );
             }
-            Integer roundedTravelToMinutes = roundMinutes(travelToMinutes);
-            Integer roundedTravelFromMinutes = roundMinutes(travelFromMinutes);
-            Integer roundenTotalTravelMinutes = roundedTravelToMinutes + roundedTravelFromMinutes;
-            Double travelHours = roundenTotalTravelMinutes / 60.0;
+            Integer totalTravelMinutes = travelToMinutes + travelFromMinutes;
+            Integer roundedTotalTravelMinutes = roundMinutes(totalTravelMinutes);
+            Double travelHours = roundedTotalTravelMinutes / 60.0;
             claimLineItem.TravelHours__c = travelHours;
 
             if (holidayDates.contains(claimDate) || isSunday) {


### PR DESCRIPTION
Det er feil at reisen til og reisen fra skal andres opprundes til neste 30 min hver for seg før de summeres. De skal summeres først, og deretter opprundes